### PR TITLE
added pre-commit hook for readable docker

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+# See <https://pre-commit.com/#new-hooks> for more information on this file.
+
+- id: readable
+  name: readable
+  language: docker_image
+  types: [markdown]
+  entry: -w /src/ ghcr.io/bobheadxi/readable fmt
+

--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@ readable -h
 Using [Docker](https://www.docker.com/):
 
 ```sh
-docker pull ghcr.io/bobheadxi/readable
 docker run -v $(pwd):/data ghcr.io/bobheadxi/readable
+```
+
+Using [pre-commit](https://pre-commit.com/) by adding to `.pre-commit-config.yaml`:
+
+```
+repos:
+  - repo: https://github.com/bobheadxi/readable
+    rev: main
+    hooks:
+      - id: readable
 ```
 
 ## Features


### PR DESCRIPTION
Resolves #20 .

Please note this won't work properly until #24 is merged and new docker image will be published.
Tested locally with local image in the meantime.