### PR TITLE
use root under docker to allow writing to all mounted volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM denoland/deno:1.19.1
-USER deno
 
 WORKDIR /bin
 COPY . .


### PR DESCRIPTION
Right now the docker command from readme doesn't work unless someone has all their files set to "writable" by EVERYTHING on the system, i.e. `chmod o+w *.md`. This is unlikely for anyone to have that, meaning the readme command will fail with write permission error.

It is not ideal to run root under docker, but since this is container and we are not creating new files (just editing existing ones) we should be fine.

An alternative would be to use:
```
docker run -v $(pwd):/data -u $(id -u):$(id -g) ghcr.io/bobheadxi/readable fmt /data/**.md
```
in README and pre-commit configuration.